### PR TITLE
Correct SPDX identifier

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,5 +18,5 @@
     "conversion"
   ],
   "author": "Valerio Proietti <@kamicane> (http://mad4milk.net)",
-  "license": "MIT (http://mootools.net/license.txt)"
+  "license": "MIT"
 }


### PR DESCRIPTION
The link to the Mootools page is no longer valid. This problem is addressed by using the correct [SPDX MIT license identifier](https://spdx.org/licenses/MIT.html). This also lets people use automated license checking tools like [nlf](https://www.npmjs.com/package/nlf).
